### PR TITLE
Fix generate_secret punctuation bug and typo for stack_events function

### DIFF
--- a/bin/cfn
+++ b/bin/cfn
@@ -113,7 +113,7 @@ function tail_stack() {
     local previous
     until echo "$current" | tail -1 | grep -E -q "${stack}.*_(COMPLETE|FAILED)"
     do
-        if ! output=$(stack-events "${stack}"); then
+        if ! output=$(stack_events "${stack}"); then
             # Something went wrong with stack-events (like stack not known)
             return 1
         fi

--- a/templates/infra.yml
+++ b/templates/infra.yml
@@ -95,6 +95,7 @@ Resources:
           import random
           import uuid
           import logging
+          import re
           
           logger = logging.getLogger()
           
@@ -147,7 +148,8 @@ Resources:
               return True
               
           def generate_secret(n):
-              chars = string.ascii_uppercase + string.ascii_lowercase + string.digits + string.punctuation
+              allowed_punctuation = re.sub('[@"/]', '', string.punctuation)
+              chars = string.ascii_uppercase + string.ascii_lowercase + string.digits + allowed_punctuation
               return ''.join(random.choice(chars) for x in range(int(n)))
           
           def handler(event, context):


### PR DESCRIPTION
Firstly, thank you for this wonderful repository!  I'm learning so much about AWS and Elixir deployments from it!

I've fixed two bugs:
1) Typo referring to a call to `stack_events`, was originally typed `stack-events`
2) Updated the `generate_secret` function to filter out disallowed password characters based on seeing this error message during deployment.
```
The  parameter MasterUserPassword is not a valid password. Only printable  ASCII characters besides '/', '@', '"', ' ' may be used. (Service:  AmazonRDS; Status Code: 400; Error Code: InvalidParameterValue; Request  ID: ce4062f4-4f7e-43b9-bb73-ff3834eb9c07)
```


