### PR TITLE
Fix repo module name in test helper

### DIFF
--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,4 +1,4 @@
 ExUnit.start()
 
-Ecto.Adapters.SQL.Sandbox.mode(DistilleryAwsExample.Repo, :manual)
+Ecto.Adapters.SQL.Sandbox.mode(Example.Repo, :manual)
 


### PR DESCRIPTION
Prior to this change the tests would fail because they used the wrong module name when attempting to start the repo. If you take a look in `lib/example/repo.ex` you can confirm that the correct repo module is `Example.Repo` not `DistilleryAwsExample.Repo`. By the way, thanks for this great reference repo, really helped me get me deploying with CodePipeline.