### PR TITLE
Use env var instead of file for GITHUB_TOKEN

### DIFF
--- a/bin/cfn
+++ b/bin/cfn
@@ -6,7 +6,7 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd -P)"
 
 STACK_NAME="${STACK_NAME:-distillery-aws-example}"
 APP_NAME="${APP_NAME:-distillery-aws-example}"
-GITHUB_TOKEN="$(cat "${SCRIPT_DIR}/../GITHUB_TOKEN" || "")"
+GITHUB_TOKEN="$GITHUB_TOKEN"
 
 GIT_URL="$(grep 'url' .git/config | awk '{ print $3 }')"
 REPO_NAME="$(echo "$GIT_URL" | sed -e 's|https://github.com/||' -e 's|git@github.com:||' -e 's|.git$||')"


### PR DESCRIPTION
The docs suggest setting `GITHUB_TOKEN` as an environment variable. But this script expects to find the token in a file called `GITHUB_TOKEN` instead. This led to some confusion when people followed the docs and created the `GITHUB_TOKEN` env var but then got an error message like `GITHUB_TOKEN: No such file or directory`. 

With the change above we now expect an env var and print `You must set GITHUB_TOKEN!` if it's not set. This is consistent with the docs and I think env var is a more secure and flexible approach than putting the token in a file.

If you prefer I can update the guide instead to use the file approach.

I realize the line `GITHUB_TOKEN="$GITHUB_TOKEN"` is redundant but perhaps it's worth leaving it in for documentations sake.

This partially resolves https://github.com/bitwalker/distillery-aws-example/issues/5