### PR TITLE
Fix cowboy dependancy issue

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -40,7 +40,7 @@ defmodule Example.Mixfile do
       {:postgrex, ">= 0.0.0"},
       {:jason, "~> 1.0"},
       {:gettext, "~> 0.11"},
-      {:cowboy, "~> 1.0"},
+      {:plug_cowboy, "~> 1.0"},
       {:distillery, "~> 2.0"},
     ]
   end


### PR DESCRIPTION
As discussed here, https://github.com/phoenixframework/phoenix/issues/3119, in some cases, with Phoenix 1.3, the endpoint will fail to start with `** (EXIT) "plug_cowboy dependency missing"` if `cowboy` instead of `plug_cowboy` is listed as a dep. I ran into that issue with this example. The proposed change, recommended in the link above, fixed it for me.