### PR TITLE
Start `ecto_sql` in migrate task

### DIFF
--- a/lib/example/tasks/migrate.ex
+++ b/lib/example/tasks/migrate.ex
@@ -10,7 +10,7 @@ defmodule Example.Tasks.Migrate do
 
     # Start requisite apps
     IO.puts "==> Starting applications.."
-    for app <- [:crypto, :ssl, :postgrex, :ecto] do
+    for app <- [:crypto, :ssl, :postgrex, :ecto, :ecto_sql] do
       {:ok, res} = Application.ensure_all_started(app)
       IO.puts "==> Started #{app}: #{inspect res}"
     end


### PR DESCRIPTION
using Ecto 3, I found that without `ecto_sql`, migrations would fail with the following error:
```
** (exit) exited in: GenServer.call(Ecto.Migration.Supervisor, {:start_child, [#PID<0.151.0>, Manager.Repo, :forward, :up, %{level: :info, sql: false}]}, :infinity)                                              
    ** (EXIT) no process: the process is not alive or there's no process currently associated with the given name, possibly because its application isn't started                                                 
    (elixir) lib/gen_server.ex:914: GenServer.call/3
    (ecto_sql) lib/ecto/migration/runner.ex:22: Ecto.Migration.Runner.run/7
    (ecto_sql) lib/ecto/migrator.ex:211: Ecto.Migrator.attempt/7
    (ecto_sql) lib/ecto/migrator.ex:113: anonymous fn/4 in Ecto.Migrator.do_up/4
    (ecto_sql) lib/ecto/migrator.ex:193: anonymous fn/3 in Ecto.Migrator.run_maybe_in_transaction/5
    (ecto_sql) lib/ecto/adapters/sql.ex:787: anonymous fn/3 in Ecto.Adapters.SQL.checkout_or_transaction/4                                                                                                        
    (db_connection) lib/db_connection.ex:1341: DBConnection.run_transaction/4
    (ecto_sql) lib/ecto/migrator.ex:192: Ecto.Migrator.run_maybe_in_transaction/5
``` 
Starting ecto_sql as shown in the proposed change, solved the problem for me. Here is a link to someone elses description of the same issue, this is where I found the solution:
https://elixirforum.com/t/migration-breaks-in-release-with-ecto-3/18320